### PR TITLE
refac: wrap todo in 'label' & clear input onSubmit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,3 +120,7 @@ button {
   flex-direction: column;
   gap: 1rem;
 }
+
+li.checked label {
+  text-decoration: line-through;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -114,5 +114,9 @@ button {
 
 .todo-list {
   height: 400px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  box-shadow: 0 2px 4px rgba(151, 137, 137, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }

--- a/index.html
+++ b/index.html
@@ -21,10 +21,12 @@
       </nav>
     </header>
     <main class="todo container">
-      <div class="todo-form dummy-class">TODO FORM HERE</div>
-      <div class="todo-list dummy-class">TODO LIST HERE</div>
+      <form class="todo-form dummy-class">
+        <input type="text" placeholder="Create a new todo" name="newTodo" />
+      </form>
+      <ul class="todo-items todo-list dummy-class"></ul>
       <div class="todo-actions dummy-class">TODO ACTIONS HERE</div>
     </main>
-    <!-- <script type="text/javascript" src="js/app.js"></script> -->
+    <script type="text/javascript" src="js/app.js"></script>
   </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,4 @@
 const todoForm = document.querySelector(".todo-form");
-const todoInput = document.querySelector(".todo-input");
 const todoItemsList = document.querySelector(".todo-items");
 
 let todos = [];
@@ -9,9 +8,9 @@ todoForm.addEventListener("submit", (e) => {
   // prevent the page from reloading when submitting the form
   e.preventDefault();
   // call addTodo function with input box current value
-  addTodo(todoInput.value);
+  addTodo(todoForm.newTodo.value);
   // finally clear the input box value
-  todoInput.value = "";
+  todoForm.newTodo.value = "";
 });
 
 // function to add todo
@@ -46,17 +45,20 @@ renderTodos = (todos) => {
     const li = document.createElement("li");
     // <li class="item"> </li>
     li.setAttribute("class", "item");
-    // <li class="item" data-key="20200708"> </li>
-    li.setAttribute("data-key", item.id);
     // if item is completed, then add a class to <li> called 'checked', which will add line-through style
     if (item.completed === true) {
       li.classList.add("checked");
     }
 
     li.innerHTML = `
-      <input type="checkbox" id="todo-${todo.id}" class="checkbox" ${checked}>
-      <label for="todo-${todo.id}">${item.name}</label>
-      <button class="delete-button">X</button>
+      <input
+        type="checkbox"
+        id="${item.id}"
+        class="checkbox"
+        onClick="toggle(${item.id})"
+        ${checked}>
+      <label for="${item.id}">${item.name}</label>
+      <button class="delete-button" onClick="deleteTodo(${item.id})">X</button>
     `;
     // finally add the <li> to the <ul>
     todoItemsList.append(li);
@@ -115,19 +117,3 @@ function deleteTodo(id) {
 
 // initially get everything from localStorage
 getFromLocalStorage();
-
-//toggle() & deleteTodo()
-
-// after that addEventListener <ul> with class=todoItems. Because we need to listen for click event in all delete-button and checkbox
-todoItemsList.addEventListener("click", (e) => {
-  // check if the event is on checkbox
-  if (e.target.type === "checkbox") {
-    // toggle the state
-    toggle(e.target.parentElement.getAttribute("data-key"));
-  }
-  // check if that is a delete-button
-  if (e.target.classList.contains("delete-button")) {
-    // get id from data-key attribute's value of parent <li> where the delete-button is present
-    deleteTodo(e.target.parentElement.getAttribute("data-key"));
-  }
-});

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,8 @@ todoForm.addEventListener("submit", (e) => {
   e.preventDefault();
   // call addTodo function with input box current value
   addTodo(todoInput.value);
+  // finally clear the input box value
+  todoInput.value = "";
 });
 
 // function to add todo
@@ -26,9 +28,6 @@ addTodo = (item) => {
     // then add it to todos array
     todos.push(todo);
     addToLocalStorage(todos); // then adding it to localStorage
-
-    // finally clear the input box value
-    todoInput.value = "";
   }
 };
 
@@ -55,8 +54,8 @@ renderTodos = (todos) => {
     }
 
     li.innerHTML = `
-      <input type="checkbox" class="checkbox" ${checked}>
-      ${item.name}
+      <input type="checkbox" id="todo-${todo.id}" class="checkbox" ${checked}>
+      <label for="todo-${todo.id}">${item.name}</label>
       <button class="delete-button">X</button>
     `;
     // finally add the <li> to the <ul>
@@ -75,9 +74,7 @@ addToLocalStorage = (todos) => {
   console.log(todos, null, 2);
 };
 
-
 // make a function called getFromLocalStorage() below the previous code, then call it.
-
 
 // function helps to get everything from local storage
 getFromLocalStorage = () => {


### PR DESCRIPTION
I think we should wrap `todo.name` inside a `label` tag so that we could toggle the complete state on the frontend. I also moved the **clearing input** part on the *submit event handler*